### PR TITLE
Fix compatibility with Python 3.x 

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -449,8 +449,13 @@ class TestOperation(PatchOperation):
     def apply(self, obj):
         try:
             subobj, part = self.locate(obj, self.location)
-        except JsonPatchConflict, c:
-            raise JsonPatchTestFailed(str(c))
+        except JsonPatchConflict:
+            exc_info = sys.exc_info()
+            exc = JsonPatchTestFailed(str(exc_info[1]))
+            if sys.version_info >= (3, 0):
+                raise exc.with_traceback(exc_info[2])
+            else:
+                raise exc
 
         val = subobj[part]
 


### PR DESCRIPTION
Used exception handling syntax is deprecated since 2.6 and removed in 3.0 (see [PEP-3110](http://www.python.org/dev/peps/pep-3110/) for details). However, the new one is invalid for Python 2.5 and older versions, so it's a little tricky to reraise exception in portable way.
