### PR TITLE
Fixed replacing whole document

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -394,6 +394,9 @@ class ReplaceOperation(PatchOperation):
         value = self.operation["value"]
         subobj, part = self.pointer.to_last(obj)
 
+        if part is None:
+            return value
+
         if isinstance(subobj, list):
             if part > len(subobj) or part < 0:
                 raise JsonPatchConflict("can't replace outside of list")

--- a/tests.py
+++ b/tests.py
@@ -56,6 +56,11 @@ class ApplyPatchTestCase(unittest.TestCase):
         res = jsonpatch.apply_patch(obj, [{'op': 'replace', 'path': '/baz', 'value': 'boo'}])
         self.assertTrue(res['baz'], 'boo')
 
+    def test_replace_whole_document(self):
+        obj = {'foo': 'bar'}
+        res = jsonpatch.apply_patch(obj, [{'op': 'replace', 'path': '', 'value': {'baz': 'qux'}}])
+        self.assertTrue(res['baz'], 'qux')
+
     def test_replace_array_item(self):
         obj = {'foo': ['bar', 'qux', 'baz']}
         res = jsonpatch.apply_patch(obj, [{'op': 'replace', 'path': '/foo/1',


### PR DESCRIPTION
- json pointer to_last operation returns None for the part in the
  case that it is a whole document pointer
- json patch now checks to see if the part is None and simply returns
  the value to replace the document
- Added a test to verify the fix
