### PR TITLE
Improve code quality

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -328,7 +328,7 @@ class JsonPatch(object):
 
     @property
     def _ops(self):
-        return map(self._get_operation, self.patch)
+        return tuple(map(self._get_operation, self.patch))
 
     def apply(self, obj, in_place=False):
         """Applies the patch to given object.


### PR DESCRIPTION
Final pylint report for Python 2.x (seems I have broken diff in report for 3.x run):

```
************* Module jsonpatch
I0011: 53: Locally disabling E0611
I0011: 53: Locally disabling W0404
I0011: 55: Locally disabling C0103
I0011: 55: Locally disabling W0622
I0011:429: Locally disabling E1103
W0212:244:JsonPatch.__eq__: Access to a protected member _ops of a client class
C0111:287:JsonPatch.from_diff.compare_values: Missing docstring
C0111:299:JsonPatch.from_diff.compare_dict: Missing docstring
C0111:313:JsonPatch.from_diff.compare_list: Missing docstring
R0912:267:JsonPatch.from_diff: Too many branches (20/12)
C0111:337:JsonPatch._ops: Missing docstring
W0141:338:JsonPatch._ops: Used builtin function 'map'
C0111:361:JsonPatch._get_operation: Missing docstring
C0103:365:JsonPatch._get_operation: Invalid name "op" (should match [a-z_][a-z0-9_]{2,30}$)
R0903:377:PatchOperation: Too few public methods (1/2)
R0903:401:RemoveOperation: Too few public methods (1/2)
R0903:414:AddOperation: Too few public methods (1/2)
R0903:446:ReplaceOperation: Too few public methods (1/2)
R0903:474:MoveOperation: Too few public methods (1/2)
R0903:499:TestOperation: Too few public methods (1/2)
R0903:522:CopyOperation: Too few public methods (1/2)


Report
======
206 statements analysed.

Messages by category
--------------------

+-----------+-------+---------+-----------+
|type       |number |previous |difference |
+===========+=======+=========+===========+
|convention |6      |18       |-12.00     |
+-----------+-------+---------+-----------+
|refactor   |8      |8        |=          |
+-----------+-------+---------+-----------+
|warning    |2      |8        |-6.00      |
+-----------+-------+---------+-----------+
|error      |0      |6        |-6.00      |
+-----------+-------+---------+-----------+



Messages
--------

+-----------+------------+
|message id |occurrences |
+===========+============+
|R0903      |7           |
+-----------+------------+
|C0111      |5           |
+-----------+------------+
|W0212      |1           |
+-----------+------------+
|W0141      |1           |
+-----------+------------+
|R0912      |1           |
+-----------+------------+
|C0103      |1           |
+-----------+------------+



Global evaluation
-----------------
Your code has been rated at 9.22/10 (previous run: 6.82/10)

Statistics by type
------------------

+---------+-------+-----------+-----------+------------+---------+
|type     |number |old number |difference |%documented |%badname |
+=========+=======+===========+===========+============+=========+
|module   |1      |1          |=          |100.00      |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|class    |11     |11         |=          |100.00      |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|method   |24     |22         |+2.00      |91.67       |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|function |7      |7          |=          |57.14       |0.00     |
+---------+-------+-----------+-----------+------------+---------+



Duplication
-----------

+-------------------------+------+---------+-----------+
|                         |now   |previous |difference |
+=========================+======+=========+===========+
|nb duplicated lines      |0     |0        |=          |
+-------------------------+------+---------+-----------+
|percent duplicated lines |0.000 |0.000    |=          |
+-------------------------+------+---------+-----------+



Raw metrics
-----------

+----------+-------+------+---------+-----------+
|type      |number |%     |previous |difference |
+==========+=======+======+=========+===========+
|code      |222    |47.54 |208      |+14.00     |
+----------+-------+------+---------+-----------+
|docstring |175    |37.47 |161      |+14.00     |
+----------+-------+------+---------+-----------+
|comment   |38     |8.14  |37       |+1.00      |
+----------+-------+------+---------+-----------+
|empty     |32     |6.85  |35       |-3.00      |
+----------+-------+------+---------+-----------+

```
