### PR TITLE
add in-place patching and patch read from stdin.  enables use of

### DIFF
--- a/bin/jsonpatch
+++ b/bin/jsonpatch
@@ -47,7 +47,8 @@ def patch_files():
             # Attempt to replace the file atomically.  We do this by
             # creating a temporary file in the same directory as the
             # original file so we can atomically move the new file over
-            # the original later.
+            # the original later.  (This is done in the same directory
+	    # because atomic renames do not work across mount points.)
 
             fd, pathname = tempfile.mkstemp(dir=dirname)
             fp = os.fdopen(fd, 'w')


### PR DESCRIPTION
jsonpatch in a shell script like so:

cat <<EOT | jsonpatch -i a.json
[{"path": "/foo", "value": "baz", "op": "replace"}]
EOT

which will edit a.json in-place and leave a backup in a.json.orig.
