### PR TITLE
Moving array item into other array item

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -466,7 +466,7 @@ class MoveOperation(PatchOperation):
         subobj, part = from_ptr.to_last(obj)
         value = subobj[part]
 
-        if self.pointer.contains(from_ptr):
+        if isinstance(subobj, dict) and self.pointer.contains(from_ptr):
             raise JsonPatchException('Cannot move values into its own children')
 
         obj = RemoveOperation({

--- a/tests.py
+++ b/tests.py
@@ -88,6 +88,12 @@ class ApplyPatchTestCase(unittest.TestCase):
         res = jsonpatch.apply_patch(obj, [{'op': 'move', 'from': '/foo/1', 'path': '/foo/3'}])
         self.assertEqual(res, {'foo': ['all', 'cows', 'eat', 'grass']})
 
+    def test_move_array_item_into_other_item(self):
+        obj = [{"foo": []}, {"bar": []}]
+        patch = [{"op": "move", "from": "/0", "path": "/0/bar/0"}]
+        res = jsonpatch.apply_patch(obj, patch)
+        self.assertEqual(res, [{'bar': [{"foo": []}]}])
+
     def test_copy_object_key(self):
         obj = {'foo': {'bar': 'baz', 'waldo': 'fred'},
                'qux': {'corge': 'grault'}}


### PR DESCRIPTION
A tiny fix for the case of moving an array item _into_ another array item whose indices collide after removing the first (see unit test for example). Not sure if this might introduce some other problem, but it seems to solve the issue in my use case.
