### PR TITLE
Catch KeyError when accessing the sub-doc items

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -398,7 +398,7 @@ class RemoveOperation(PatchOperation):
         subobj, part = self.pointer.to_last(obj)
         try:
             del subobj[part]
-        except IndexError as ex:
+        except (KeyError, IndexError) as ex:
             raise JsonPatchConflict(str(ex))
 
         return obj
@@ -464,7 +464,10 @@ class MoveOperation(PatchOperation):
     def apply(self, obj):
         from_ptr = JsonPointer(self.operation['from'])
         subobj, part = from_ptr.to_last(obj)
-        value = subobj[part]
+        try:
+            value = subobj[part]
+        except (KeyError, IndexError) as ex:
+            raise JsonPatchConflict(str(ex))
 
         if isinstance(subobj, dict) and self.pointer.contains(from_ptr):
             raise JsonPatchException('Cannot move values into its own children')
@@ -512,7 +515,10 @@ class CopyOperation(PatchOperation):
     def apply(self, obj):
         from_ptr = JsonPointer(self.operation['from'])
         subobj, part = from_ptr.to_last(obj)
-        value = copy.deepcopy(subobj[part])
+        try:
+            value = copy.deepcopy(subobj[part])
+        except (KeyError, IndexError) as ex:
+            raise JsonPatchConflict(str(ex))
 
         obj = AddOperation({
             'op': 'add',

--- a/tests.py
+++ b/tests.py
@@ -75,6 +75,12 @@ class ApplyPatchTestCase(unittest.TestCase):
                                            'value': 'boo'}])
         self.assertEqual(res['foo'], ['bar', 'boo', 'baz'])
 
+    def test_move_object_keyerror(self):
+        obj = {'foo': {'bar': 'baz'},
+               'qux': {'corge': 'grault'}}
+        patch_obj = [ {'op': 'move', 'from': '/foo/non-existent', 'path': '/qux/thud'} ]
+        self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, obj, patch_obj)
+
     def test_move_object_key(self):
         obj = {'foo': {'bar': 'baz', 'waldo': 'fred'},
                'qux': {'corge': 'grault'}}
@@ -93,6 +99,12 @@ class ApplyPatchTestCase(unittest.TestCase):
         patch = [{"op": "move", "from": "/0", "path": "/0/bar/0"}]
         res = jsonpatch.apply_patch(obj, patch)
         self.assertEqual(res, [{'bar': [{"foo": []}]}])
+
+    def test_copy_object_keyerror(self):
+        obj = {'foo': {'bar': 'baz'},
+               'qux': {'corge': 'grault'}}
+        patch_obj = [{'op': 'copy', 'from': '/foo/non-existent', 'path': '/qux/thud'}]
+        self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, obj, patch_obj)
 
     def test_copy_object_key(self):
         obj = {'foo': {'bar': 'baz', 'waldo': 'fred'},
@@ -313,6 +325,11 @@ class ConflictTests(unittest.TestCase):
         src = {"foo": [1, 2]}
         patch_obj = [ { "op": "remove", "path": "/foo/b"} ]
         self.assertRaises(jsonpointer.JsonPointerException, jsonpatch.apply_patch, src, patch_obj)
+
+    def test_remove_keyerror_dict(self):
+        src = {'foo': {'bar': 'barz'}}
+        patch_obj = [ { "op": "remove", "path": "/foo/non-existent"} ]
+        self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
 
     def test_insert_oob(self):
         src = {"foo": [1, 2]}


### PR DESCRIPTION
In [12]: doc = {'param1': 1, 'param2': {'oi' :'ola'}}
In [13]: patch = [{'op': 'remove', 'path': '/invalid'}]
## In [14]: jsonpatch.apply_patch(doc, jsonpatch.JsonPatch(patch))

KeyError                                  Traceback (most recent call last)
<ipython-input-14-4533e42f88c2> in <module>()
----> 1 jsonpatch.apply_patch(doc, jsonpatch.JsonPatch(patch))

/usr/lib/python2.7/site-packages/jsonpatch.pyc in apply_patch(doc, patch, in_place)
    139     else:
    140         patch = JsonPatch(patch)
--> 141     return patch.apply(doc, in_place)
    142 
    143 def make_patch(src, dst):

/usr/lib/python2.7/site-packages/jsonpatch.pyc in apply(self, obj, in_place)
    342 
    343         for operation in self._ops:
--> 344             obj = operation.apply(obj)
    345 
    346         return obj

/usr/lib/python2.7/site-packages/jsonpatch.pyc in apply(self, obj)
    393         subobj, part = self.pointer.to_last(obj)
    394         try:
--> 395             del subobj[part]
    396         except IndexError as ex:
    397             raise JsonPatchConflict(str(ex))
