### PR TITLE
Improve error message when removing non-existent objects

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -399,7 +399,8 @@ class RemoveOperation(PatchOperation):
         try:
             del subobj[part]
         except IndexError as ex:
-            raise JsonPatchConflict(str(ex))
+            msg = "can't remove non-existent object '{0}'".format(part)
+            raise JsonPatchConflict(msg)
 
         return obj
 


### PR DESCRIPTION
The message before wasn't very intuitive :)

In [6]: doc = {'a': 1, 'b': 2}
## In [7]: jsonpatch.apply_patch(doc, jsonpatch.JsonPatch(patch))

JsonPatchConflict                         Traceback (most recent call last)
<ipython-input-7-4533e42f88c2> in <module>()
----> 1 jsonpatch.apply_patch(doc, jsonpatch.JsonPatch(patch))

/usr/lib/python2.7/site-packages/jsonpatch.pyc in apply_patch(doc, patch, in_place)
    140     else:
    141         patch = JsonPatch(patch)
--> 142     return patch.apply(doc, in_place)
    143 
    144 

/usr/lib/python2.7/site-packages/jsonpatch.pyc in apply(self, obj, in_place)
    336 
    337         for operation in self._ops:
--> 338             obj = operation.apply(obj)
    339 
    340         return obj

/usr/lib/python2.7/site-packages/jsonpatch.pyc in apply(self, obj)
    388             del subobj[part]
    389         except (KeyError, IndexError) as ex:
--> 390             raise JsonPatchConflict(str(ex))
    391 
    392         return obj

JsonPatchConflict: u'c'
