### PR TITLE
Added Python 3.4 and PyPy3 to the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4" 
   - "pypy"
+  - "pypy3"
 
 install:
-  - pip install -r requirements.txt
-  - pip install coveralls --use-mirrors
+  - travis_retry pip install -r requirements.txt
+  - travis_retry pip install coveralls
 
 script:
   - coverage run --source=jsonpatch tests.py


### PR DESCRIPTION
Also used travis_retry in order to avoid build failures due to networking problems and removed --use-mirrors since it's deprecated.
