### PR TITLE
Prevent inspect.getargspec failure on get_loadjson

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -104,8 +104,9 @@ def get_loadjson():
     methods returns an unmodified json.load for Python 2.6 and a partial
     function with object_pairs_hook set to multidict for Python versions that
     support the parameter. """
-
-    if sys.version_info >= (3, 3):
+    if isinstance(json.load, functools.partial):
+        return json.load
+    elif sys.version_info >= (3, 3):
         args = inspect.signature(json.load).parameters
     else:
         args = inspect.getargspec(json.load).args


### PR DESCRIPTION
I was running into an issue with nosetests where jsonpatch would attempt to overwrite json.load after it already had done so in a previous testcase. The call to inspect.getargspec would fail since previously it had changed json.load to an instance of functools.partial. Just wanted to open this PR to highlight the issue I saw and give the workaround that I used.