### PR TITLE
Avoid double work

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -179,7 +179,7 @@ def make_patch(src, dst):
     if new != dst:
         return JsonPatch.from_diff(src, dst, False)
 
-    return JsonPatch.from_diff(src, dst)
+    return patch
 
 
 class JsonPatch(object):


### PR DESCRIPTION
In the case where the optimized patch is not invalid, we shouldn't need to calculate the patch again.