### PR TITLE
Add property based test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 dist
 *.egg-info/
 doc/_build
+.hypothesis/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ python:
   - "pypy3"
 
 install:
-  - travis_retry pip install -r requirements.txt -r requirements-dev.txt
+  - travis_retry pip install -r requirements.txt
+  - if [ "$TRAVIS_PYTHON_VERSION" != "2.6" -a "$TRAVIS_PYTHON_VERSION" != "3.2" -a "$TRAVIS_PYTHON_VERSION" != "3.3" ]; then travis_retry pip install hypothesis; fi
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install 'coverage<4'; fi
   - travis_retry pip install coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   - "pypy3"
 
 install:
-  - travis_retry pip install -r requirements.txt
+  - travis_retry pip install -r requirements.txt -r requirements-dev.txt
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install 'coverage<4'; fi
   - travis_retry pip install coveralls
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 wheel
 pypandoc
+hypothesis >= 3

--- a/tests.py
+++ b/tests.py
@@ -10,11 +10,17 @@ import jsonpatch
 import jsonpointer
 import sys
 import string
+
 try:
     import hypothesis
     from hypothesis import strategies as st
 except ImportError:
     hypothesis = None
+
+try:
+    unicode
+except NameError:
+    unicode = str
 
 
 class ApplyPatchTestCase(unittest.TestCase):
@@ -536,8 +542,8 @@ if hypothesis is not None:
         | st.dictionaries(st.text(string.printable), children))
 
     class RoundtripTests(unittest.TestCase):
-        @hypothesis.example({}, {u'%20': None})
-        @hypothesis.example({u'%20': None}, {})
+        @hypothesis.example({}, {unicode('%20'): None})
+        @hypothesis.example({unicode('%20'): None}, {})
         @hypothesis.given(json_st, json_st)
         def test_roundtrip(self, src, dst):
             patch = jsonpatch.JsonPatch.from_diff(src, dst, False)

--- a/tests.py
+++ b/tests.py
@@ -536,6 +536,8 @@ if hypothesis is not None:
         | st.dictionaries(st.text(string.printable), children))
 
     class RoundtripTests(unittest.TestCase):
+        @hypothesis.example({}, {u'%20': None})
+        @hypothesis.example({u'%20': None}, {})
         @hypothesis.given(json_st, json_st)
         def test_roundtrip(self, src, dst):
             patch = jsonpatch.JsonPatch.from_diff(src, dst, False)

--- a/tests.py
+++ b/tests.py
@@ -524,7 +524,7 @@ json_st = st.recursive(
     st.one_of([
         st.none(),
         st.booleans(),
-        st.floats(),
+        st.floats(allow_nan=False),
         st.text(string.printable)]),
     lambda children:
     st.lists(children)


### PR DESCRIPTION
This PR adds a property-based test using Hypothesis, that tests that a patch from a randomly generated source value to a randomly generated destination value is valid (yields the destination value when applied to the source value). This would have been able to find the bug in #55, among other things.

The test is currently failing due to an issue with jsonpointer that I'm not entirely sure how to fix. The first problem is that jsonpointer expects pointers to be urlencoded, which I don't think is correct (my reading of the RFC is that urlencoding should only be used when the pointer is part of a URL, so nothing special to JSON pointer itself). The second issue is that `JsonPointer.from_parts([u'%00'])` ends up generating a pointer of `/\u0000` due to the parts being urldecoded; this is tangled up with the first issue.

I'm happy to do the work to resolve these issues, but I'm not entirely sure what direction to go in, so would appreciate some guidance here. I think the correct thing for jsonpointer to do is to not do any url encoding/decoding at all, but of course this represents a fairly large change in the API.