### PR TITLE
fixing array diff bug (issue #30)

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -175,7 +175,11 @@ def make_patch(src, dst):
     # TODO: fix patch optimiztion and remove the following check
     # fix when patch with optimization is incorrect
     patch = JsonPatch.from_diff(src, dst)
-    new = patch.apply(src)
+    try:
+        new = patch.apply(src) 
+    except JsonPatchConflict: # see TODO
+        return JsonPatch.from_diff(src, dst, False)
+    
     if new != dst:
         return JsonPatch.from_diff(src, dst, False)
 
@@ -601,7 +605,6 @@ def _longest_common_subseq(src, dst):
                 matrix[i][j] = matrix[i-1][j-1] + 1
             if matrix[i][j] > z:
                 z = matrix[i][j]
-            if matrix[i][j] == z:
                 range_src = (i-z+1, i+1)
                 range_dst = (j-z+1, j+1)
         else:

--- a/tests.py
+++ b/tests.py
@@ -376,7 +376,15 @@ class MakePatchTestCase(unittest.TestCase):
         patch = jsonpatch.make_patch(old, new)
         new_from_patch = jsonpatch.apply_patch(old, patch)
         self.assertEqual(new, new_from_patch)
-
+    
+    def test_arrays_one_element_sequences(self):
+        """ Tests the case of multiple common one element sequences inside an array """
+        # see https://github.com/stefankoegl/python-json-patch/issues/30#issuecomment-155070128
+        src = [1,2,3]
+        dst = [3,1,4,2]
+        patch = jsonpatch.make_patch(src, dst)
+        res = jsonpatch.apply_patch(src, patch)
+        self.assertEqual(res, dst)
 
 class OptimizationTests(unittest.TestCase):
     def test_use_replace_instead_of_remove_add(self):


### PR DESCRIPTION
@apinkney97 It seems that this is caused within `_split_by_common_seq()`.  The problem is that it sticks with the latest matched "sequence". Thus, it skips 1 and 2 and in our case produces: `[ [(0, 2), None], [None, (1, 4)] ]`. If we instead start from our first match (which is 1) it should produce: `[[None, (0, 1)], [[None, (2, 3)], [(2, 3), None]]]` which, as it turns out, plays well with the rest of the logic.

I think my update fixes the issue, however optimization with move does not work in this particular case. So, I have added a temporary workaround until I investigate further.

@stefankoegl Test run fine on my setup, but please do make sure that I am not missing something.