### PR TITLE
Remove extraneous 'value' field for op:remove (#76)

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -730,7 +730,6 @@ class DiffBuilder(object):
         new_op = RemoveOperation({
             'op': 'remove',
             'path': _path_join(path, key),
-            'value': item,
         })
         index = self.take_index(item, _ST_ADD)
         new_index = self.insert(new_op)


### PR DESCRIPTION
RFC 6902 section 4.2 [0] does not define a 'value' field for
the 'remove' operation.  The commit "Merge _op_base classes
into PatchOperation classes" [1] introduced a 'value' field
in _item_removed() in the DiffBuilder class.  This patch
removes the 'value' field from the 'remove' operation, adds
a new test, and revises some other tests.

[0] https://tools.ietf.org/html/rfc6902#section-4.2
[1] https://github.com/stefankoegl/python-json-patch/commit/03aa14e8209d59522476726d55bfabf86a28929e