### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
-python-json-patch [![Build Status](https://secure.travis-ci.org/stefankoegl/python-json-patch.png?branch=master)](https://travis-ci.org/stefankoegl/python-json-patch) [![Coverage Status](https://coveralls.io/repos/stefankoegl/python-json-patch/badge.png?branch=master)](https://coveralls.io/r/stefankoegl/python-json-patch?branch=master)
+python-json-patch
 =================
+
+[![PyPI version](https://img.shields.io/pypi/v/jsonpatch.svg)](https://pypi.python.org/pypi/jsonpatch/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/jsonpatch.svg)](https://pypi.python.org/pypi/jsonpatch/)
+[![Build Status](https://travis-ci.org/stefankoegl/python-json-patch.png?branch=master)](https://travis-ci.org/stefankoegl/python-json-patch)
+[![Coverage Status](https://coveralls.io/repos/stefankoegl/python-json-patch/badge.png?branch=master)](https://coveralls.io/r/stefankoegl/python-json-patch?branch=master)
+
 Applying JSON Patches in Python
 -------------------------------
 
 Library to apply JSON Patches according to
 [RFC 6902](http://tools.ietf.org/html/rfc6902)
 
-See Sourcecode for Examples
+See source code for examples
 
 * Website: https://github.com/stefankoegl/python-json-patch
 * Repository: https://github.com/stefankoegl/python-json-patch.git
 * Documentation: https://python-json-patch.readthedocs.org/
 * PyPI: https://pypi.python.org/pypi/jsonpatch
-* Travis-CI: https://travis-ci.org/stefankoegl/python-json-patch
+* Travis CI: https://travis-ci.org/stefankoegl/python-json-patch
 * Coveralls: https://coveralls.io/r/stefankoegl/python-json-patch
 
 Running external tests

--- a/bin/jsondiff
+++ b/bin/jsondiff
@@ -4,7 +4,6 @@
 from __future__ import print_function
 
 import sys
-import os.path
 import json
 import jsonpatch
 import argparse

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ python-json-patch
 =================
 
 *python-json-patch* is a Python library for applying JSON patches (`RFC 6902
-<http://tools.ietf.org/html/rfc6902>`_). Python 2.7 and 3.3-3.6 are
+<http://tools.ietf.org/html/rfc6902>`_). Python 2.7 and 3.4+ are
 supported. Tests are run on both CPython and PyPy.
 
 

--- a/ext_tests.py
+++ b/ext_tests.py
@@ -34,7 +34,6 @@
 """ Script to run external tests, eg from
 https://github.com/json-patch/json-patch-tests """
 
-from functools import partial
 import doctest
 import unittest
 import jsonpatch

--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -37,8 +37,6 @@ from __future__ import unicode_literals
 import collections
 import copy
 import functools
-import inspect
-import itertools
 import json
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import io
 import re
-import warnings
 try:
     from setuptools import setup
     has_setuptools = True

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
@@ -81,5 +80,6 @@ setup(name=PACKAGE,
       package_data={'': ['requirements.txt']},
       scripts=['bin/jsondiff', 'bin/jsonpatch'],
       classifiers=CLASSIFIERS,
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       **OPTIONS
 )

--- a/tests.py
+++ b/tests.py
@@ -366,7 +366,7 @@ class MakePatchTestCase(unittest.TestCase):
 
         src = [8, 7, 2, 1, 0, 9, 4, 3, 5, 6]
         dest = [7, 2, 1, 0, 9, 4, 3, 6, 5, 8]
-        patch = jsonpatch.make_patch(src, dest)
+        jsonpatch.make_patch(src, dest)
 
     def test_issue76(self):
         """ Make sure op:remove does not include a 'value' field """


### PR DESCRIPTION
Python 3.3 was dropped in dependency python-json-pointer in https://github.com/stefankoegl/python-json-pointer/pull/28.

---

PS The intro text needs updating to something like "Applying JSON Patches in Python 2.7 and 3.4+", or just "Applying JSON Patches in Python".

![image](https://user-images.githubusercontent.com/1324225/34989020-8cc29bbc-fac9-11e7-8234-ac29d98f291d.png)
