### PR TITLE
Ensure an item is within the upper array boundaries before replacing it

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -474,7 +474,7 @@ class ReplaceOperation(PatchOperation):
             return value
 
         if isinstance(subobj, MutableSequence):
-            if part > len(subobj) or part < 0:
+            if part >= len(subobj) or part < 0:
                 raise JsonPatchConflict("can't replace outside of list")
 
         elif isinstance(subobj, MutableMapping):

--- a/tests.py
+++ b/tests.py
@@ -602,6 +602,11 @@ class ConflictTests(unittest.TestCase):
         patch_obj = [ { "op": "replace", "path": "/foo/10", "value": 10} ]
         self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
 
+    def test_replace_oob_length(self):
+        src = {"foo": [0, 1]}
+        patch_obj = [ { "op": "replace", "path": "/foo/2", "value": 2} ]
+        self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
+
     def test_replace_missing(self):
         src = {"foo": 1}
         patch_obj = [ { "op": "replace", "path": "/bar", "value": 10} ]


### PR DESCRIPTION
This will avoid an exception when trying to replace the item at the last position of an array:
```
ERROR: test_replace_oob_length (tests.ConflictTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/guillaume/src/jsonpatch/tests.py", line 608, in test_replace_oob_length
    self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
  File "/home/linuxbrew/.linuxbrew/var/pyenv/versions/3.7/lib/python3.7/unittest/case.py", line 743, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/home/linuxbrew/.linuxbrew/var/pyenv/versions/3.7/lib/python3.7/unittest/case.py", line 178, in handle
    callable_obj(*args, **kwargs)
  File "/home/guillaume/src/jsonpatch/jsonpatch.py", line 143, in apply_patch
    return patch.apply(doc, in_place)
  File "/home/guillaume/src/jsonpatch/jsonpatch.py", line 312, in apply
    obj = operation.apply(obj)
  File "/home/guillaume/src/jsonpatch/jsonpatch.py", line 490, in apply
    subobj[part] = value
IndexError: list assignment index out of range

----------------------------------------------------------------------
```