### PR TITLE
Make it possible for from_diff to support custom types (issue #107)

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -649,7 +649,7 @@ class CopyOperation(PatchOperation):
 
 class DiffBuilder(object):
 
-    def __init__(self, dumps):
+    def __init__(self, dumps=json.dumps):
         self.dumps = dumps
         self.index_storage = [{}, {}]
         self.index_storage2 = [[], []]

--- a/tests.py
+++ b/tests.py
@@ -268,6 +268,34 @@ class EqualityTestCase(unittest.TestCase):
         self.assertEqual(json.dumps(patch_obj), patch.to_string())
 
 
+def custom_types_dumps(obj):
+    def default(obj):
+        if isinstance(obj, decimal.Decimal):
+            return {'__decimal__': str(obj)}
+        raise TypeError('Unknown type')
+
+    return json.dumps(obj, default=default)
+
+
+def custom_types_loads(obj):
+    def as_decimal(dct):
+        if '__decimal__' in dct:
+            return decimal.Decimal(dct['__decimal__'])
+        return dct
+
+    return json.loads(obj, object_hook=as_decimal)
+
+
+class CustomTypesJsonPatch(jsonpatch.JsonPatch):
+    @staticmethod
+    def json_dumper(obj):
+        return custom_types_dumps(obj)
+
+    @staticmethod
+    def json_loader(obj):
+        return custom_types_loads(obj)
+
+
 class MakePatchTestCase(unittest.TestCase):
 
     def test_apply_patch_to_copy(self):
@@ -446,18 +474,33 @@ class MakePatchTestCase(unittest.TestCase):
         self.assertEqual(res, dst)
         self.assertIsInstance(res['A'], float)
 
-    def test_custom_types(self):
-        def default(obj):
-            if isinstance(obj, decimal.Decimal):
-                return str(obj)
-            raise TypeError('Unknown type')
-
-        def dumps(obj):
-            return json.dumps(obj, default=default)
-
+    def test_custom_types_diff(self):
         old = {'value': decimal.Decimal('1.0')}
         new = {'value': decimal.Decimal('1.00')}
-        patch = jsonpatch.JsonPatch.from_diff(old, new, dumps=dumps)
+        generated_patch = jsonpatch.JsonPatch.from_diff(
+            old, new,  dumps=custom_types_dumps)
+        str_patch = generated_patch.to_string(dumps=custom_types_dumps)
+        loaded_patch = jsonpatch.JsonPatch.from_string(
+            str_patch, loads=custom_types_loads)
+        self.assertEqual(generated_patch, loaded_patch)
+        new_from_patch = jsonpatch.apply_patch(old, generated_patch)
+        self.assertEqual(new, new_from_patch)
+
+    def test_custom_types_subclass(self):
+        old = {'value': decimal.Decimal('1.0')}
+        new = {'value': decimal.Decimal('1.00')}
+        generated_patch = CustomTypesJsonPatch.from_diff(old, new)
+        str_patch = generated_patch.to_string()
+        loaded_patch = CustomTypesJsonPatch.from_string(str_patch)
+        self.assertEqual(generated_patch, loaded_patch)
+        new_from_patch = jsonpatch.apply_patch(old, loaded_patch)
+        self.assertEqual(new, new_from_patch)
+
+    def test_custom_types_subclass_load(self):
+        old = {'value': decimal.Decimal('1.0')}
+        new = {'value': decimal.Decimal('1.00')}
+        patch = CustomTypesJsonPatch.from_string(
+            '[{"op": "replace", "path": "/value", "value": {"__decimal__": "1.00"}}]')
         new_from_patch = jsonpatch.apply_patch(old, patch)
         self.assertEqual(new, new_from_patch)
 


### PR DESCRIPTION
This makes it possible to pass a custom `dumps` implementation to `from_diff` to support types not natively supported by Python's json module.

I have not dealt with `from_string` and `to_string` which also use the json module. The easy solution here would be to deprecate them and rely on people using whichever implementation of json dumping and loading they prefer.