### PR TITLE
fix #111:  optimizing exception message

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -334,12 +334,18 @@ class PatchOperation(object):
 
     def __init__(self, operation):
 
+        if not operation.__contains__('path'):
+            raise InvalidJsonPatch("Operation must have a 'path' member")
+
         if isinstance(operation['path'], JsonPointer):
             self.location = operation['path'].path
             self.pointer = operation['path']
         else:
             self.location = operation['path']
-            self.pointer = JsonPointer(self.location)
+            try:
+                self.pointer = JsonPointer(self.location)
+            except TypeError as ex:
+                raise InvalidJsonPatch("Invalid 'path'")
 
         self.operation = operation
 

--- a/tests.py
+++ b/tests.py
@@ -219,6 +219,17 @@ class ApplyPatchTestCase(unittest.TestCase):
             ])
         self.assertEqual(res['foo'], [1, 2, 3, 4])
 
+    def test_add_missing_path(self):
+        obj = {'bar': 'qux'}
+        self.assertRaises(jsonpatch.InvalidJsonPatch,
+                          jsonpatch.apply_patch,
+                          obj, [{'op': 'test', 'value': 'bar'}])
+
+    def test_path_with_null_value(self):
+        obj = {'bar': 'qux'}
+        self.assertRaises(jsonpatch.InvalidJsonPatch,
+                          jsonpatch.apply_patch,
+                          obj, '[{"op": "add", "path": null, "value": "bar"}]')
 
 
 class EqualityTestCase(unittest.TestCase):


### PR DESCRIPTION
see #111, when missing `path` member or `path` is null, the ambiguous exception message confuses people.