### PR TITLE
fix #102: optimize error handling

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -473,6 +473,9 @@ class ReplaceOperation(PatchOperation):
         if part is None:
             return value
 
+        if part == "-":
+            raise InvalidJsonPatch("'path' with '-' can't be applied to 'replace' operation")
+
         if isinstance(subobj, MutableSequence):
             if part >= len(subobj) or part < 0:
                 raise JsonPatchConflict("can't replace outside of list")


### PR DESCRIPTION
As described in #102, when `path` with `-`, it will report `TypeError: '>' not supported between instances of 'str' and 'int'` in python3 , which is not conducive to positioning errors.