### PR TITLE
Add support for preserving Unicode characters in jsonpatch CLI

### DIFF
--- a/bin/jsonpatch
+++ b/bin/jsonpatch
@@ -24,7 +24,8 @@ parser.add_argument('-i', '--in-place', action='store_true',
                     help='Modify ORIGINAL in-place instead of to stdout')
 parser.add_argument('-v', '--version', action='version',
                     version='%(prog)s ' + jsonpatch.__version__)
-
+parser.add_argument('-u', '--preserve-unicode', action='store_true',
+                    help='Output Unicode character as-is without using Code Point')
 
 def main():
     try:
@@ -72,8 +73,8 @@ def patch_files():
 
     # By this point we have some sort of file object we can write the 
     # modified JSON to.
-
-    json.dump(result, fp, indent=args.indent)
+    
+    json.dump(result, fp, indent=args.indent, ensure_ascii=not(args.preserve_unicode))
     fp.write('\n')
 
     if args.in_place:

--- a/doc/commandline.rst
+++ b/doc/commandline.rst
@@ -74,10 +74,12 @@ The program ``jsonpatch`` is used to apply JSON patches on JSON files. ::
       PATCH            Patch file
 
     optional arguments:
-      -h, --help       show this help message and exit
-      --indent INDENT  Indent output by n spaces
-      -v, --version    show program's version number and exit
-
+     -h, --help             show this help message and exit
+     --indent INDENT        Indent output by n spaces
+     -b, --backup           Back up ORIGINAL if modifying in-place
+     -i, --in-place         Modify ORIGINAL in-place instead of to stdout
+     -v, --version          show program's version number and exit
+     -u, --preserve-unicode Output Unicode character as-is without using Code Point
 
 Example
 ^^^^^^^


### PR DESCRIPTION
If the JSON content contains some Unicode characters, the jsonpatch
final output will encode the Unicode character using ASCII (i.e
`\u0394`). This behaviour comes from the module `json.dump()` governed
by a flag `ensure_ascii`[1].

For example:

```json
/* patch.json */
[{
  "op": "add",
  "path": "/SomeUnicodeSamples",
  "value": "𝒞𝘋𝙴𝓕ĢȞỈ𝕵 đ áê 🤩 äÄöÖüÜß"
}]
```

After applying the patch on an empty source file `{}`, this is the
output:

```json
{"SomeUnicodeSamples": "\ud835\udc9e\ud835\ude0b...\u00fc\u00dc\u00df"}
```

This commits add a flag `-u|--preserve-unicode` into the jsonpatch CLI
to configure the behaviour of `json.dump`'s `ensure_ascii` flag.

Using the `--preserve-unicode` flag, the final output will print the
Unicode characters as-is without any encoding.

[1]: https://docs.python.org/3/library/json.html#basic-usage