### PR TITLE
FIX: TypeError when one forgot to put its operation in a list.

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -558,6 +558,19 @@ class JsonPatch(object):
         # Much of the validation is done in the initializer
         # though some is delayed until the patch is applied.
         for op in self.patch:
+            # We're only checking for basestring in the following check
+            # for two reasons:
+            #
+            # - It should come from JSON, which only allows strings as
+            #   dictionary keys, so having a string here unambiguously means
+            #   someone used: {"op": ..., ...} instead of [{"op": ..., ...}].
+            #
+            # - There's no possible false positive: if someone give a sequence
+            #   of mappings, this won't raise.
+            if isinstance(op, basestring):
+                raise InvalidJsonPatch("Document is expected to be sequence of "
+                                       "operations, got a sequence of strings.")
+
             self._get_operation(op)
 
     def __str__(self):
@@ -677,7 +690,7 @@ class JsonPatch(object):
         op = operation['op']
 
         if not isinstance(op, basestring):
-            raise InvalidJsonPatch("Operation must be a string")
+            raise InvalidJsonPatch("Operation's op must be a string")
 
         if op not in self.operations:
             raise InvalidJsonPatch("Unknown operation {0!r}".format(op))

--- a/tests.py
+++ b/tests.py
@@ -190,6 +190,12 @@ class ApplyPatchTestCase(unittest.TestCase):
                           obj, [{'op': 'test', 'path': '/baz', 'value': 'bar'}])
 
 
+    def test_forgetting_surrounding_list(self):
+        obj =  {'bar': 'qux'}
+        self.assertRaises(jsonpatch.InvalidJsonPatch,
+                          jsonpatch.apply_patch,
+                          obj, {'op': 'test', 'path': '/bar'})
+
     def test_test_noval_existing(self):
         obj =  {'bar': 'qux'}
         self.assertRaises(jsonpatch.InvalidJsonPatch,


### PR DESCRIPTION
Closes https://github.com/stefankoegl/python-json-patch/issues/131

```
>>> import jsonpatch
>>> jsonpatch.JsonPatch({'op': 'add', 'path': '/foo', 'value': 'bar'})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mdk/clones/stefankoegl/python-json-patch/jsonpatch.py", line 561, in __init__
    self._get_operation(op)
  File "/home/mdk/clones/stefankoegl/python-json-patch/jsonpatch.py", line 675, in _get_operation
    raise InvalidJsonPatch("Operation is expected to be a mapping, got a string.")
jsonpatch.InvalidJsonPatch: Operation is expected to be a mapping, got a string.
```