### PR TITLE
B/fix invalid remove index

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -39,6 +39,12 @@ import copy
 import functools
 import json
 import sys
+
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:  # Python 3
+    from collections import Mapping, Sequence
+
 try:
     from types import MappingProxyType
 except ImportError:
@@ -234,6 +240,10 @@ class RemoveOperation(PatchOperation):
 
     def apply(self, obj):
         subobj, part = self.pointer.to_last(obj)
+
+        if isinstance(subobj, Sequence) and not isinstance(part, int):
+            raise JsonPointerException("invalid array index '{0}'".format(part))
+
         try:
             del subobj[part]
         except (KeyError, IndexError) as ex:

--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -41,9 +41,9 @@ import json
 import sys
 
 try:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 except ImportError:  # Python 3
-    from collections import Mapping, Sequence
+    from collections import Sequence
 
 try:
     from types import MappingProxyType

--- a/tests.py
+++ b/tests.py
@@ -87,6 +87,12 @@ class ApplyPatchTestCase(unittest.TestCase):
         res = jsonpatch.apply_patch(obj, [{'op': 'remove', 'path': '/foo/1'}])
         self.assertEqual(res['foo'], ['bar', 'baz'])
 
+    def test_remove_invalid_item(self):
+        obj = {'foo': ['bar', 'qux', 'baz']}
+        with self.assertRaises(jsonpointer.JsonPointerException):
+            jsonpatch.apply_patch(obj, [{'op': 'remove', 'path': '/foo/-'}])
+
+
     def test_replace_object_key(self):
         obj = {'foo': 'bar', 'baz': 'qux'}
         res = jsonpatch.apply_patch(obj, [{'op': 'replace', 'path': '/baz', 'value': 'boo'}])


### PR DESCRIPTION
### Reference issue: https://github.com/stefankoegl/python-json-patch/issues/133

### What does this fix?
Attempt to remove a dash "-" element of an array will raise a `JsonPatchConflict` instead of `TypeError`. 