### PR TITLE
docs: fix simple typo, raies -> raises

### DIFF
--- a/ext_tests.py
+++ b/ext_tests.py
@@ -86,7 +86,7 @@ def add_test_method(cls, name, test):
 
 
 
-modules = ['jsonpatch']F
+modules = ['jsonpatch']
 coverage_modules = []
 
 

--- a/ext_tests.py
+++ b/ext_tests.py
@@ -65,7 +65,7 @@ class TestCaseTemplate(unittest.TestCase):
                 raise Exception(test.get('comment', '')) from jpe
 
             # if there is no 'expected' we only verify that applying the patch
-            # does not raies an exception
+            # does not raises an exception
             if 'expected' in test:
                 self.assertEquals(res, test['expected'], test.get('comment', ''))
 

--- a/ext_tests.py
+++ b/ext_tests.py
@@ -65,7 +65,7 @@ class TestCaseTemplate(unittest.TestCase):
                 raise Exception(test.get('comment', '')) from jpe
 
             # if there is no 'expected' we only verify that applying the patch
-            # does not raises an exception
+            # does not raise an exception
             if 'expected' in test:
                 self.assertEquals(res, test['expected'], test.get('comment', ''))
 
@@ -86,7 +86,7 @@ def add_test_method(cls, name, test):
 
 
 
-modules = ['jsonpatch']
+modules = ['jsonpatch']F
 coverage_modules = []
 
 


### PR DESCRIPTION
There is a small typo in ext_tests.py.

Should read `raises` rather than `raies`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md