### PR TITLE
feat(jsondiff): Add support for preserving Unicode characters in jsondiff CLI

### DIFF
--- a/bin/jsondiff
+++ b/bin/jsondiff
@@ -14,6 +14,8 @@ parser.add_argument('FILE1', type=argparse.FileType('r'))
 parser.add_argument('FILE2', type=argparse.FileType('r'))
 parser.add_argument('--indent', type=int, default=None,
                     help='Indent output by n spaces')
+parser.add_argument('-u', '--preserve-unicode', action='store_true',
+                    help='Output Unicode character as-is without using Code Point')
 parser.add_argument('-v', '--version', action='version',
                     version='%(prog)s ' + jsonpatch.__version__)
 
@@ -32,7 +34,7 @@ def diff_files():
     doc2 = json.load(args.FILE2)
     patch = jsonpatch.make_patch(doc1, doc2)
     if patch.patch:
-        print(json.dumps(patch.patch, indent=args.indent))
+        print(json.dumps(patch.patch, indent=args.indent, ensure_ascii=not(args.preserve_unicode)))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/doc/commandline.rst
+++ b/doc/commandline.rst
@@ -10,7 +10,7 @@ The JSON patch package contains the commandline utilities ``jsondiff`` and
 The program ``jsondiff`` can be used to create a JSON patch by comparing two
 JSON files ::
 
-    usage: jsondiff [-h] [--indent INDENT] [-v] FILE1 FILE2
+    usage: jsondiff [-h] [--indent INDENT] [-u] [-v] FILE1 FILE2
 
     Diff two JSON files
 
@@ -19,9 +19,10 @@ JSON files ::
       FILE2
 
     optional arguments:
-      -h, --help       show this help message and exit
-      --indent INDENT  Indent output by n spaces
-      -v, --version    show program's version number and exit
+      -h, --help             show this help message and exit
+      --indent INDENT        Indent output by n spaces
+      -u, --preserve-unicode Output Unicode character as-is without using Code Point
+      -v, --version          show program's version number and exit
 
 Example
 ^^^^^^^


### PR DESCRIPTION
Mostly same as https://github.com/stefankoegl/python-json-patch/pull/127.
This is also for jsondiff.

Example:
t1.json: `{"test": "test"}`
t2.json: `{"test": "テスト"}`

Without the support:
```sh
$ jsondiff t1.json t2.json 
[{"op": "replace", "path": "/test", "value": "\u30c6\u30b9\u30c8"}]
```

With the support:
```sh
$ jsondiff -u t1.json t2.json
[{"op": "replace", "path": "/test", "value": "テスト"}]
```