### PR TITLE
Fix tests for Python 3.12

### DIFF
--- a/ext_tests.py
+++ b/ext_tests.py
@@ -67,7 +67,7 @@ class TestCaseTemplate(unittest.TestCase):
             # if there is no 'expected' we only verify that applying the patch
             # does not raise an exception
             if 'expected' in test:
-                self.assertEquals(res, test['expected'], test.get('comment', ''))
+                self.assertEqual(res, test['expected'], test.get('comment', ''))
 
 
 def make_test_case(tests):


### PR DESCRIPTION
unittest.TestCase.assertEquals has been removed in Python 3.12;
unittest.TestCase.assertEqual should be used instead[1].

[1] https://docs.python.org/3/whatsnew/3.12.html#id3
