### PR TITLE
Fix make_patch TypeError for numeric-string dict key moves

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -797,7 +797,12 @@ class DiffBuilder(object):
         index = self.take_index(item, _ST_REMOVE)
         if index is not None:
             op = index[2]
-            if type(op.key) == int and type(key) == int:
+            # We can't rely on the op.key type since PatchOperation casts
+            # the .key property to int and this path wrongly ends up being taken
+            # for numeric string dict keys while the intention is to only handle lists.
+            # So we do an explicit check on the item affected by the op instead.
+            removed_from = op.pointer.to_last(self.src_doc)[0]
+            if type(removed_from) == list:
                 for v in self.iter_from(index):
                     op.key = v._on_undo_remove(op.path, op.key)
 

--- a/tests.py
+++ b/tests.py
@@ -526,6 +526,20 @@ class MakePatchTestCase(unittest.TestCase):
         res = jsonpatch.apply_patch(src, patch)
         self.assertEqual(res, dst)
 
+    def test_make_patch_added_numeric_str_dict_key(self):
+        """Avoid casting numeric str dict key to int on the add/move side.
+
+        Symmetric to the _item_removed fix (issues 119/120): _item_added must
+        not treat a removed numeric-string dict key (cast to int by
+        PatchOperation.key) as a list index, which raised a TypeError while
+        building the move.
+        """
+        src = {'0': [], 'd': [], 'a': [-1, {'a': ['s']}]}
+        dst = {'d': [0, []], 'c': ['s2']}
+        patch = jsonpatch.make_patch(src, dst)
+        res = jsonpatch.apply_patch(src, patch)
+        self.assertEqual(res, dst)
+
     def test_issue120(self):
         """Make sure it avoids casting numeric str dict key to int"""
         src = [{'foobar': {'821b7213_b9e6_2b73_2e9c_cf1526314553': ['Open Work'],


### PR DESCRIPTION
## Summary

`make_patch` raises an uncaught `TypeError` instead of producing a valid patch when the diff moves a list element while a numeric-string dict key is also removed:

```python
import jsonpatch
jsonpatch.make_patch({'0': [], 'd': [], 'a': [-1, {'a': ['s']}]},
                     {'d': [0, []], 'c': ['s2']})
# TypeError: '>=' not supported between instances of 'str' and 'int'
```

## Cause

`DiffBuilder._item_added` guarded its index-shifting undo loop with `type(op.key) == int and type(key) == int`. But `PatchOperation.key` casts numeric-string dict keys (e.g. `"0"`) to `int`, so a *dict-key* removal at `/0` passes the `int` check and wrongly enters the loop. The loop then calls `_on_undo_remove` on sibling ops, and a `RemoveOperation` with a genuine string key (`'a'`) hits `if self.key >= key:`, comparing `'a' >= 0` → `TypeError`.

The sibling `_item_removed` already fixed this exact bug class for issues #119/#120 by checking the affected container's type instead of trusting `op.key`'s type; `_item_added` was left with the old heuristic.

## Fix

Mirror the `_item_removed` fix: check whether the removed item's container in `src_doc` is a `list` (using `op.pointer.to_last(self.src_doc)[0]`) rather than relying on the int-cast key. The destination key type is irrelevant to whether the source remove-index needs shifting, so — like `_item_removed` — the redundant `type(key) == int` check is dropped.

`make_patch` now returns a valid, round-tripping patch (`[remove /a, add /c, add /d/0, move /0→/d/1]`) for these inputs.

## Verification

- Added a regression test (symmetric to `test_issue119`/`test_issue120`) that fails before the fix with the `TypeError`.
- Full suite: **117 tests OK**.
- A 40k-pair `make_patch`/`apply_patch` round-trip fuzz, run identically against the previous code and this change: this fix is a strict subset of the prior failures (it introduces **zero** new failures) and additionally repairs round-trip cases where a list element moves into a dict key. The few remaining fuzz failures are distinct, pre-existing issues (move/add ordering) left out to keep this PR focused.

This pull request was prepared with the assistance of AI, under my direction and review.
