### PR TITLE
Configure pytest to collect tests.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[tool:pytest]
+python_files = tests.py


### PR DESCRIPTION
## Summary
- configure pytest to collect the existing `tests.py` module by default
- leave the existing `python tests.py` runner unchanged

## Tests
- `python -m pytest -q`
- `python tests.py`
- `git diff --check`

Closes #150