### PR TITLE
Fix test operation to respect JSON types (boolean vs number)

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -98,6 +98,34 @@ class JsonPatchTestFailed(JsonPatchException, AssertionError):
     """ A Test operation failed """
 
 
+def _compare_json_values(left, right):
+    """Compare two JSON values for equality as required by RFC 6902.
+
+    Two values are only considered equal if they are of the same JSON
+    type. This needs special handling because in Python ``bool`` is a
+    subclass of ``int`` (so ``True == 1`` and ``False == 0``), whereas in
+    JSON the ``true``/``false`` literals are a distinct type from numbers.
+    Containers are compared recursively so the same rule applies to values
+    nested inside arrays and objects.
+    """
+    if isinstance(left, bool) or isinstance(right, bool):
+        return isinstance(left, bool) and isinstance(right, bool) \
+            and left == right
+
+    if isinstance(left, MutableMapping) and isinstance(right, MutableMapping):
+        return left.keys() == right.keys() and all(
+            _compare_json_values(left[key], right[key]) for key in left
+        )
+
+    if isinstance(left, MutableSequence) and isinstance(right, MutableSequence):
+        return len(left) == len(right) and all(
+            _compare_json_values(lval, rval)
+            for lval, rval in zip(left, right)
+        )
+
+    return left == right
+
+
 def multidict(ordered_pairs):
     """Convert duplicate keys values to lists."""
     # read all values into lists
@@ -468,7 +496,7 @@ class TestOperation(PatchOperation):
             raise InvalidJsonPatch(
                 "The operation does not contain a 'value' member")
 
-        if val != value:
+        if not _compare_json_values(val, value):
             msg = '{0} ({1}) is not equal to tested value {2} ({3})'
             raise JsonPatchTestFailed(msg.format(val, type(val),
                                                  value, type(value)))

--- a/tests.py
+++ b/tests.py
@@ -222,6 +222,41 @@ class ApplyPatchTestCase(unittest.TestCase):
                           jsonpatch.apply_patch,
                           obj, [{'op': 'test', 'path': '/baz/qx'}])
 
+    def test_test_bool_and_int_not_equal(self):
+        # RFC 6902 requires the tested value to be of the same JSON type,
+        # so the number 1 must not test-equal the boolean true (in Python
+        # True == 1), and likewise 0 must not test-equal false.
+        self.assertRaises(jsonpatch.JsonPatchTestFailed,
+                          jsonpatch.apply_patch,
+                          {'baz': 1}, [{'op': 'test', 'path': '/baz', 'value': True}])
+        self.assertRaises(jsonpatch.JsonPatchTestFailed,
+                          jsonpatch.apply_patch,
+                          {'baz': True}, [{'op': 'test', 'path': '/baz', 'value': 1}])
+        self.assertRaises(jsonpatch.JsonPatchTestFailed,
+                          jsonpatch.apply_patch,
+                          {'baz': 0}, [{'op': 'test', 'path': '/baz', 'value': False}])
+
+    def test_test_bool_matches_bool(self):
+        # Same-typed boolean values still test-equal.
+        obj = {'baz': True}
+        res = jsonpatch.apply_patch(obj, [{'op': 'test', 'path': '/baz', 'value': True}])
+        self.assertEqual(res, obj)
+
+    def test_test_int_and_float_equal(self):
+        # Numbers are compared numerically, so 1 and 1.0 test-equal.
+        obj = {'baz': 1}
+        res = jsonpatch.apply_patch(obj, [{'op': 'test', 'path': '/baz', 'value': 1.0}])
+        self.assertEqual(res, obj)
+
+    def test_test_bool_and_int_nested_not_equal(self):
+        # The same-type rule also applies to values nested in containers.
+        self.assertRaises(jsonpatch.JsonPatchTestFailed,
+                          jsonpatch.apply_patch,
+                          {'baz': [1]}, [{'op': 'test', 'path': '/baz', 'value': [True]}])
+        self.assertRaises(jsonpatch.JsonPatchTestFailed,
+                          jsonpatch.apply_patch,
+                          {'baz': {'q': 1}}, [{'op': 'test', 'path': '/baz', 'value': {'q': True}}])
+
 
     def test_unrecognized_element(self):
         obj = {'foo': 'bar', 'baz': 'qux'}


### PR DESCRIPTION
### What

The `test` operation currently compares values with a plain `!=`. Because Python treats `bool` as a
subclass of `int` (`True == 1`, `False == 0`), a `test` against the JSON `true`/`false` literal
incorrectly succeeds against the numbers `1`/`0`, and vice versa.

```python
import jsonpatch
# Each of these wrongly succeeds today (no JsonPatchTestFailed raised):
jsonpatch.apply_patch({"baz": 1},    [{"op": "test", "path": "/baz", "value": True}])
jsonpatch.apply_patch({"baz": True}, [{"op": "test", "path": "/baz", "value": 1}])
jsonpatch.apply_patch({"baz": 0},    [{"op": "test", "path": "/baz", "value": False}])
```

### Why

RFC 6902 §4.6 defines `test` equality as requiring the two values to be "of the same JSON type". A
boolean literal and a number are different JSON types and must not compare equal. This mirrors the
intent already present in `DiffBuilder._compare_values`, which uses `json.dumps` specifically so it
can "recognize the difference between 1 and True".

### How

Adds a small recursive helper, `_compare_json_values`, that keeps booleans distinct from numbers,
still compares numbers numerically (`1 == 1.0`), and recurses into arrays and objects so the rule
also holds for nested values. `TestOperation.apply` uses it in place of `!=`. The error type and
message are unchanged; there is no public API change.

### Tests

Adds regression tests covering scalar `bool`/number mismatches in both directions, the `0`/`false`
case, `1`/`1.0` numeric equality (still passes), same-typed booleans (still pass), and nested
`[1]` vs `[true]` / `{"q": 1}` vs `{"q": true}` cases. Full suite: 114 passing.
