### PR TITLE
Raise JsonPatchConflict instead of TypeError on invalid move/copy/remove targets

### DIFF
--- a/jsonpatch.py
+++ b/jsonpatch.py
@@ -246,7 +246,10 @@ class RemoveOperation(PatchOperation):
 
         try:
             del subobj[part]
-        except (KeyError, IndexError) as ex:
+        except (KeyError, IndexError, TypeError) as ex:
+            # TypeError happens when subobj is not a mutable container, e.g. a
+            # pointer into a string value ("str object doesn't support item
+            # deletion").
             msg = "can't remove a non-existent object '{0}'".format(part)
             raise JsonPatchConflict(msg)
 
@@ -379,7 +382,9 @@ class MoveOperation(PatchOperation):
         subobj, part = from_ptr.to_last(obj)
         try:
             value = subobj[part]
-        except (KeyError, IndexError) as ex:
+        except (KeyError, IndexError, TypeError) as ex:
+            # TypeError happens when the 'from' pointer ends in '-' (the
+            # array-append token), so part is a string used to index a list.
             raise JsonPatchConflict(str(ex))
 
         # If source and target are equal, this is a no-op
@@ -489,7 +494,9 @@ class CopyOperation(PatchOperation):
         subobj, part = from_ptr.to_last(obj)
         try:
             value = copy.deepcopy(subobj[part])
-        except (KeyError, IndexError) as ex:
+        except (KeyError, IndexError, TypeError) as ex:
+            # TypeError happens when the 'from' pointer ends in '-' (the
+            # array-append token), so part is a string used to index a list.
             raise JsonPatchConflict(str(ex))
 
         obj = AddOperation({

--- a/tests.py
+++ b/tests.py
@@ -764,6 +764,25 @@ class ConflictTests(unittest.TestCase):
         patch_obj = [ { "op": "remove", "path": "/foo/non-existent"} ]
         self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
 
+    def test_copy_from_dash_on_array(self):
+        # 'from' ending in '-' indexes a list with a string; used to raise a
+        # bare TypeError.
+        src = [1, 2, 3]
+        patch_obj = [ { "op": "copy", "path": "/0", "from": "/-"} ]
+        self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
+
+    def test_move_from_dash_on_array(self):
+        src = [1, 2, 3]
+        patch_obj = [ { "op": "move", "path": "/0", "from": "/-"} ]
+        self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
+
+    def test_remove_index_into_string(self):
+        # A pointer into a string value is not a mutable container; deleting
+        # from it used to raise a bare TypeError.
+        src = {"foo": "bar"}
+        patch_obj = [ { "op": "remove", "path": "/foo/0"} ]
+        self.assertRaises(jsonpatch.JsonPatchConflict, jsonpatch.apply_patch, src, patch_obj)
+
     def test_insert_oob(self):
         src = {"foo": [1, 2]}
         patch_obj = [ { "op": "add", "path": "/foo/10", "value": 1} ]


### PR DESCRIPTION
Some patches make `apply_patch` raise a bare `TypeError` instead of a `JsonPatchConflict`:

```python
import jsonpatch
jsonpatch.apply_patch([1, 2, 3], [{'op': 'copy', 'path': '/0', 'from': '/-'}])
# TypeError: list indices must be integers or slices, not str
jsonpatch.apply_patch({'foo': 'bar'}, [{'op': 'remove', 'path': '/foo/0'}])
# TypeError: 'str' object doesn't support item deletion
```

`move`/`copy` read `subobj[part]` from the `from` pointer and `remove` does `del subobj[part]`. When the pointer ends in `-` (the array-append token), `part` is the string `'-'` used to index a list; when it points into a string value the container is immutable. Both raise `TypeError`, which isn't in the `except (KeyError, IndexError)` clauses. I added `TypeError` to those three clauses so the operations report `JsonPatchConflict` like other invalid targets. Valid moves/copies/removes are unaffected.

Added three tests to `ConflictTests`; they raise TypeError on `master` and pass with the change, and the full suite still passes. Found it by fuzzing `apply_patch` with random patches.